### PR TITLE
fix: arstechica.com

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ dist/mercury_test.js.map
 dist/mercury_test.web.js
 tmp/artifacts
 test-output.json
+.DS_Store

--- a/src/extractors/custom/arstechnica.com/index.test.js
+++ b/src/extractors/custom/arstechnica.com/index.test.js
@@ -13,12 +13,15 @@ describe('ArstechnicaComExtractor', () => {
     let result;
     let url;
     beforeAll(() => {
-      url =
-        'https://arstechnica.com/gadgets/2016/08/the-connected-renter-how-to-make-your-apartment-smarter/';
+      url = 'https://arstechnica.com/?p=1665636';
       const html = fs.readFileSync(
         './fixtures/arstechnica.com/1587927767738.html'
       );
-      result = Mercury.parse(url, { html, fallback: false });
+      result = Mercury.parse(url, {
+        html,
+        fallback: false,
+        fetchAllPages: false,
+      });
     });
 
     it('is selected properly', () => {
@@ -88,15 +91,18 @@ describe('ArstechnicaComExtractor', () => {
       );
     });
 
-    // it('returns the pages_rendered', async () => {
-    //     // To pass this test, fill out the pages_rendered selector
-    //     // in ./src/extractors/custom/arstechnica.com/index.js.
-    //     const { pages_rendered } = await result
-    //
-    //     // Update these values with the expected values from
-    //     // the article.
-    //     assert.equal(pages_rendered, `3`)
-    //   });
+    it('returns the next_page_url', async () => {
+      // To pass this test, fill out the lead_image_url selector
+      // in ./src/extractors/custom/arstechnica.com/index.js.
+      const { next_page_url } = await result;
+
+      // Update these values with the expected values from
+      // the article.
+      assert.equal(
+        next_page_url,
+        `https://arstechnica.com/gadgets/2016/08/the-connected-renter-how-to-make-your-apartment-smarter/2`
+      );
+    });
 
     it('returns the content', async () => {
       // To pass this test, fill out the content selector
@@ -132,7 +138,11 @@ describe('ArstechnicaComExtractor', () => {
       const html = fs.readFileSync(
         './fixtures/arstechnica.com/1587927767738.html'
       );
-      result = Mercury.parse(url, { html, fallback: false });
+      result = Mercury.parse(url, {
+        html,
+        fallback: false,
+        fetchAllPages: false,
+      });
     });
 
     it('is selected properly', () => {

--- a/src/extractors/root-extractor.js
+++ b/src/extractors/root-extractor.js
@@ -74,7 +74,15 @@ export function select(opts) {
   // contributors), return the string
   if (typeof extractionOpts === 'string') return extractionOpts;
 
-  const { selectors, defaultCleaner = true, allowMultiple } = extractionOpts;
+  const {
+    selectors,
+    locator,
+    defaultCleaner = true,
+    allowMultiple,
+  } = extractionOpts;
+  if (locator) {
+    return locator($, opts.url);
+  }
 
   const matchingSelector = findMatchingSelector(
     $,
@@ -191,11 +199,12 @@ function extractResult(opts) {
   if (result) {
     return result;
   }
-
   // If nothing matches the selector, and fallback is enabled,
   // run the Generic extraction
-  if (fallback) return GenericExtractor[type](opts);
-
+  if (fallback) {
+    const fallbackResult = GenericExtractor[type](opts);
+    return fallbackResult;
+  }
   return null;
 }
 


### PR DESCRIPTION
Pagination worked for full URLs, but not in the short URLs that Ars Technica puts in its RSS feeds. The
reason was that the parser takes the request URL into account when determining whether a link might be
to a subsequent page. That uses the requested URL, not the served URL.

I ended up implementing the ability to get the attribute with a JavaScript function instead of a simple
selector.

<!--
Thanks for submitting a pull request!

In order to get this change merged in a timely manner, please provide a short
description, review requirements, and a link to the issue this addresses (if applicable).

Contributing Guide: https://github.com/postlight/mercury-parser/blob/master/CONTRIBUTING.md
-->
