### PR TITLE
fix: Allow Mercury Parser to cache responses with no Content-Type header

### DIFF
--- a/src/resource/index.js
+++ b/src/resource/index.js
@@ -44,7 +44,11 @@ const Resource = {
 
     // TODO: Implement is_text function from
     // https://github.com/ReadabilityHoldings/readability/blob/8dc89613241d04741ebd42fa9fa7df1b1d746303/readability/utils/text.py#L57
-    if (!contentType.includes('html') && !contentType.includes('text')) {
+    if (
+      !contentType.includes('html') &&
+      !contentType.includes('text') &&
+      contentType !== ''
+    ) {
       throw new Error('Content does not appear to be text.');
     }
 

--- a/src/resource/index.test.js
+++ b/src/resource/index.test.js
@@ -97,22 +97,12 @@ describe('Resource', () => {
       }, /content does not appear to be text/i);
     });
 
-    it('throws an error if the response has no Content-Type header', () => {
+    it('does not throw an error if the response has no Content-Type header', () => {
       const response = {
         headers: {},
       };
-      const body = '';
-
-      // This assertion is more elaborate than the others to be sure that we're
-      // throwing an `Error` and not raising a runtime exception.
-      assert.throws(
-        () => {
-          Resource.generateDoc({ body, response });
-        },
-        err =>
-          err instanceof Error &&
-          /content does not appear to be text/i.test(err)
-      );
+      const body = '<p>hello</p>';
+      Resource.generateDoc({ body, response });
     });
 
     it('throws an error if the content has no children', () => {


### PR DESCRIPTION
If an HTTP response has no Content-Type header, at least try to parse the response.